### PR TITLE
Init game error reporting

### DIFF
--- a/NationsBot/Cogs/AdminCommands.py
+++ b/NationsBot/Cogs/AdminCommands.py
@@ -149,6 +149,9 @@ class AdminCommands(commands.Cog):
                 "Test World", 
                 "Test Gamerule"
                 )
+        except InputError as e:
+            raise e
+            return
         except Exception as e:
             raise NonFatalError("This server already has a savegame assigned to it")
             return

--- a/NationsBot/Cogs/AdminCommands.py
+++ b/NationsBot/Cogs/AdminCommands.py
@@ -149,11 +149,11 @@ class AdminCommands(commands.Cog):
                 "Test World", 
                 "Test Gamerule"
                 )
-        except InputError as e:
+        except CustomException as e:
             raise e
             return
         except Exception as e:
-            raise NonFatalError("This server already has a savegame assigned to it")
+            raise NonFatalError("Something went wrong when initializing the savegame.")
             return
 
         logInfo(f"Successfully created savegame {savegame.name} for server {ctx.guild.id}")

--- a/NationsBot/ConcertOfNationsEngine/CustomExceptions.py
+++ b/NationsBot/ConcertOfNationsEngine/CustomExceptions.py
@@ -1,18 +1,22 @@
 from logger import *
 
-class NonFatalError(Exception):
+class CustomException(Exception):
+    pass
+
+
+class NonFatalError(CustomException):
     
     def __init__(self, args):
         super().__init__(args)
         logInfo(str(args[0]))
 
-class InputError(Exception):
+class InputError(CustomException):
     
     def __init__(self, args):
         super().__init__(args)
         logInfo(f"Input Error: \"{str(args)}\"")
 
-class GameError(Exception):
+class GameError(CustomException):
     
     def __init__(self, args):
         super().__init__(args)

--- a/NationsBot/Testing/GenerateGame.py
+++ b/NationsBot/Testing/GenerateGame.py
@@ -138,7 +138,7 @@ def testSuite():
     
     testWorld = generateTestWorld(100, 100, 20)
 
-    savegame = generateGame(testWorld)
+    #savegame = generateGame(testWorld)
 
-    testTerritoryTransfer(savegame, "Test_(20,20)", "Nation02")
+    #testTerritoryTransfer(savegame, "Test_(20,20)", "Nation02")
 


### PR DESCRIPTION
The command for initializing a game used to not print anything helpful for InputErrors etc., that has now been fixed by catching custom errors. Also created a CustomException parent class for custom errors for this purpose.