### PR TITLE
fix: world map images now save to the correct folder, whereas previously they were saved in the current working directory

### DIFF
--- a/NationsBot/ConcertOfNationsEngine/GameObjects.py
+++ b/NationsBot/ConcertOfNationsEngine/GameObjects.py
@@ -92,7 +92,7 @@ class Savegame:
 
         logInfo("Retrieved nation colors")
 
-        filename = f"{self.name}_{self.turn}-{self.gamestate['mapNum']}"
+        filename = f"{worldsDir}/{self.name}_{self.turn}-{self.gamestate['mapNum']}"
         worldfile = world.toImage(mapScale = mapScale, colorRules = colorRules, filename = filename)
 
         link = imgur.upload(f"{worldsDir}/{worldfile}")


### PR DESCRIPTION
…sly they were saved in the current working directory