### PR TITLE
Nations can now accept trades sent to them and view trades in which t…

### DIFF
--- a/NationsBot/Cogs/infocommands.py
+++ b/NationsBot/Cogs/infocommands.py
@@ -476,16 +476,6 @@ class InfoCommands(commands.Cog):
         await ctx.send(embed = menu.toEmbed(), view = menu.embedView())
 
 
-    # Trade Information
-    @commands.command()
-    async def trade(self, ctx):
-        """ 
-        Show all of the ongoing trade in a game.
-        """
-        logInfo(f"trade({ctx.guild.id})")
-
-
-
     # Population Information
 
     def nation_population(self, ctx, nation):

--- a/NationsBot/Cogs/tradecommands.py
+++ b/NationsBot/Cogs/tradecommands.py
@@ -17,6 +17,7 @@ from ConcertOfNationsEngine.concertofnations_exceptions import *
 from ConcertOfNationsEngine import trade as trade
 
 from GameUtils.filehandling import *
+from GameUtils import operations as ops
 
 #Util functions
 
@@ -26,12 +27,12 @@ def nation_trade_offers(ctx, nation, savegame):
     """
 
     sent_trades = [] if nation.name not in savegame.offers else [
-            (f"Offered to {recipient}", trade)
+            (f"Offered to {recipient}", ops.invertDict(trade))
             for recipient, trade in savegame.offers[nation.name].items()
         ]
 
     recieved_trades = [
-            (f"Sent by {sender}", {resource: amount * -1 for resource, amount in trade.items()})
+            (f"Sent by {sender}", trade)
             for sender, trade in
         {sender: offers[nation.name] for sender, offers in savegame.offers.items() if nation.name in offers.keys()}.items()
     ]
@@ -56,8 +57,79 @@ class TradeCommands(commands.Cog):
     def __init__(self, client):
         self.client = client
         
+
+    # Trade Information
+
+    @commands.command()
+    async def trade(self, ctx, roleid = None):
+        """ 
+        Show all of a nation's ongoing trade.
+        Args:
+            roleid: The nation role. By default it's the nation belonging to the user.
+        """
+        logInfo(f"trade({ctx.guild.id})")
+
+        savegame = get_SavegameFromCtx(ctx)
+
+        if (not roleid):
+
+            playerinfo = get_player_byGame(savegame, ctx.author.id)
+
+            if not (playerinfo):
+                raise InputError(f"Could not get a nation for player <@{ctx.author.id}>")
+
+            roleid = playerinfo['role_discord_id']
+            logInfo(f"Got default role id {roleid} for this player")
+
+        nation = get_NationFromRole(ctx, roleid, savegame)
+
+        trade_menu = MenuEmbed(
+        f"{nation.name} Trade", 
+        "_Positive numbers are imports, and negative numbers are exports._", 
+        ctx.author.id,
+        fields = [(target, trade) for target, trade in nation.trade.items()],
+        pagesize = 5,
+        sortable = True,
+        isPaged = True
+        )
+
+        assignMenu(ctx.author.id, trade_menu)
+
+        logInfo(f"Created trade menu and assigned it to player {ctx.author.id}")
+
+        await ctx.send(embed = trade_menu.toEmbed(), view = trade_menu.embedView())
+
+
+    @commands.command(aliases = ["tradeoffers", "trade-offers", "tradeOffers"])
+    async def trade_offers(self, ctx):
+        """
+        See all trade offers where your nation is either the target or the offerer.
+        """
+        logInfo(f"trade_offers({ctx.guild.id})")
+
+        savegame = get_SavegameFromCtx(ctx)
+
+        #Validate that the player owns this territory
+        playerinfo = get_player_byGame(savegame, ctx.author.id)
+
+        if not (playerinfo):
+            raise InputError(f"Could not get a nation for player <@{ctx.author.id}>")
+
+        roleid = playerinfo['role_discord_id']
+
+        nation = get_NationFromRole(ctx, roleid, savegame)
+        
+        trade_menu = nation_trade_offers(ctx, nation, savegame)
+
+        assignMenu(ctx.author.id, trade_menu)
+
+        logInfo(f"Created trade offers menu and assigned it to player {ctx.author.id}")
+
+        await ctx.send(embed = trade_menu.toEmbed(), view = trade_menu.embedView())
+       
+
     @commands.command(aliases = ["offertrade", "offer-trade", "offerTrade"])
-    async def offer_trade(self, ctx, target_roleid = None, *args):
+    async def offer_trade(self, ctx, target_roleid, *args):
         """
         Offer trade to another nation. Positive numbers will be your exports to them, and negative numbers will be your imports from them.
         Args:
@@ -89,17 +161,19 @@ class TradeCommands(commands.Cog):
 
         nation.offer_trade(savegame, target_nation, resources_toadd)
 
-        logInfo(f"Successfully sent trade offer", details = {"Sender": nation.name, "Recipient": target_nation.name, "Resources": nation.resources})
+        logInfo(f"Successfully sent trade offer", details = {"Sender": nation.name, "Recipient": target_nation.name, "Trade": resources_toadd})
         await ctx.send("Successfully sent trade offer, type \"_n.trade\_offers_\" to view offer")
 
         save_saveGame(savegame)
-
-    @commands.command(aliases = ["tradeoffers", "trade-offers", "tradeOffers"])
-    async def trade_offers(self, ctx):
+ 
+    @commands.command(aliases = ["accepttrade", "accept-trade", "acceptTrade"])
+    async def accept_trade(self, ctx, target_roleid):
         """
-        See all trade offers where your nation is either the target or the offerer.
+        Accept another nation's trade offer.
+        Args:
+            roleid: The target nation role.
         """
-        logInfo(f"trade_offers({ctx.guild.id})")
+        logInfo(f"accept_trade({ctx.guild.id}, {target_roleid})")
 
         savegame = get_SavegameFromCtx(ctx)
 
@@ -112,28 +186,28 @@ class TradeCommands(commands.Cog):
         roleid = playerinfo['role_discord_id']
 
         nation = get_NationFromRole(ctx, roleid, savegame)
+
+        target_nation = get_NationFromRole(ctx, target_roleid, savegame)
+
+        if (nation == target_nation):
+            raise InputError(f"Cannot trade with self!")
+
+        if not(target_nation.name in savegame.offers.keys()):
+            raise InputError(f"No offers exist from other nation!")
+
+        if not(nation.name in savegame.offers[target_nation.name].keys()):
+            raise InputError(f"No offer exists to you from other nation!")
+
+        accepted_trade = nation.accept_trade(savegame, target_nation)
+
+        logInfo(f"Successfully accepted trade offer", details = {"Nation": nation.name, "Sender": target_nation.name, "Trade": accepted_trade})
+        await ctx.send(f"Successfully accepted trade offer from {nation.name}, type \"_n.trade_\" to view offer")
+
+        save_saveGame(savegame)
         
-        trade_menu = nation_trade_offers(ctx, nation, savegame)
-
-        assignMenu(ctx.author.id, trade_menu)
-
-        logInfo(f"Created trade offers menu and assigned it to player {ctx.author.id}")
-
-        await ctx.send(embed = trade_menu.toEmbed(), view = trade_menu.embedView())
-        
-    @commands.command(aliases = ["accepttrade", "accept-trade", "acceptTrade"])
-    async def accept_trade(self, ctx, roleid = None):
-        """
-        Accept another nation's trade offer.
-        Args:
-            roleid: The target nation role.
-        """
-        logInfo(f"accept_trade({ctx.guild.id}, {roleid})")
-
-        pass
         
     @commands.command(aliases = ["canceltrade", "cancel-trade", "cancelTrade"])
-    async def cancel_trade(self, ctx, roleid = None):
+    async def cancel_trade(self, ctx, roleid):
         """
         Cancel or reject trade or a trade offer with another nation.
         Args:

--- a/NationsBot/ConcertOfNationsEngine/gameobjects.py
+++ b/NationsBot/ConcertOfNationsEngine/gameobjects.py
@@ -29,7 +29,6 @@ class Savegame:
         date (dict): Represents the ingame month (m) and year (y)
         turn (int): The turn number that the game is currently on
         nations (dict): Contains all the nations that populate the game, controlled by players.
-        trade (dict): Contains all trade between nations.
         offers (dict): Contains all proposed deals between nations.
 
         gamestate (dict): Describes seperate aspects of the game as it presently exists. Format:
@@ -51,7 +50,6 @@ class Savegame:
         self.turn = turn
 
         self.nations = nations or dict()
-        self.trade = trade or dict()
         self.offers = offers or dict()
         self.gamestate = gamestate or {
             "mapChanged": True,
@@ -349,13 +347,19 @@ class Nation:
     Represents a nation, which controls a number of territories and ingame objects such as buildings and armies, as well as having an economy, meaning resources and their production.
 
     Attributes:
+        name (str): The nation's name.
+        mapcolor (tuple): The RGB values of the color which the nation will be displayed as on a map.
         resources (dict): Represents the total resources available for spending by the nation.
         territories (list): Holds the name of every territory owned by the nation.
+        military (dict): All forces and therefore all units controlled by this nation.
         bureaucracy (dict): Represents the capacity and current load on each bureaucratic category of the nation, with values being tuples (load, capacity)
-        tax_modifier (float): Added onto the base national tax rate and used to calculate the tax revenue from the national population
-    """
+        role_id (int): The discord role id associated with this nation.
+        diplomacy (dict): All diplomatic relations with other nations.
+        trade (dict): Contains trade information by partner nation, with each entry a dict of resources.
+        modifiers (dict): Contains all modifiable values for this nation.
+        """
 
-    def __init__(self, name, role_id, mapcolor, resources = None, territories = None, bureaucracy = None, military = None, diplomacy = None, modifiers = None):
+    def __init__(self, name, role_id, mapcolor, resources = None, territories = None, bureaucracy = None, military = None, diplomacy = None, trade = None, modifiers = None):
         self.name = name
         self.mapcolor = mapcolor
         self.resources = resources or dict()
@@ -369,6 +373,8 @@ class Nation:
         self.role_id = role_id
 
         self.diplomacy = diplomacy or dict()
+
+        self.trade = trade or dict()
         
         self.modifiers = modifiers or copy(nationmodifiers_template)
 
@@ -715,7 +721,7 @@ class Nation:
 
     def offer_trade(self, savegame, target, resources):
         """
-        Offer trade to another target nation.
+        Offer trade to another target nation. Trade can be retrieved at savegame[self.name][target.name]
         """
         
         existing_offers = dict() if self.name not in savegame.offers.keys() else savegame.offers[self.name]
@@ -727,8 +733,19 @@ class Nation:
         return savegame.offers[self.name][target.name]
 
 
-    def accept_trade(self, target):
-        pass
+    def accept_trade(self, savegame, target):
+        """
+        Accept trade from another target nation, adding it to the savegame's ongoing trades.
+        """
+
+        offer = savegame.offers[target.name].pop(self.name)
+
+        self.trade[target.name] = offer
+
+        target.trade[self.name] = ops.invertDict(offer)
+
+        return offer
+
 
     def stop_trade(self, target):
         pass

--- a/NationsBot/GameUtils/operations.py
+++ b/NationsBot/GameUtils/operations.py
@@ -48,6 +48,35 @@ def combineDicts(*args, subtractDicts = False):
 
     return rtnDict
 
+def invertValue(v):
+
+    if isinstance(v, (int, float)):
+        return v*-1
+    elif isinstance(v, (dict)):
+        return invertDict(v)
+    elif (isinstance(v, list)):
+        return invertList(v)
+    else:
+        return v
+
+def invertList(l):
+
+    invertedList = list()
+    
+    for i, v in enumerate(l):
+        invertedList[i] = invertValue(v)
+
+    return invertedList
+
+def invertDict(d):
+
+    invertedDict = dict()
+
+    for k, v in d.items():
+        invertedDict[k] = invertValue(v)
+
+    return invertedDict
+
 def isInt(inStr: str):
      return bool(re.search("^-?[1234567890]*$", inStr))
 


### PR DESCRIPTION
Command accept_trade allows a nation to accept a pending trade sent its way.
Command trade allows a user to view their own trade or that of a specified nation.